### PR TITLE
release: 1.0.0 beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
+## [1.0.0-beta.3] - 2023-08-04
+- feat!: Move `WordPress.WP.I18n.MissingTranslatorsComment` from `WPGraphQL-Strict` to `WPGraphQL-Minimum`. (Added to WPGraphQL in https://github.com/wp-graphql/wp-graphql/pull/2856)
+- feat!: Move `SlevomatCodingStandard.Functions.StaticClosure` from `WPGraphQL-Strict` to `WPGraphQL-Minimum`. (Added to WPGraphQL in https://github.com/wp-graphql/wp-graphql/pull/2855)
+- chore: Update `slevomat/coding-standard` to `8.13.4`.
+- chore: Update Composer dev-deps.
+
 ## [1.0.0-beta.2] - 2023-06-17
 - dev: Remove `Squiz.Commenting.FunctionComment.ParamCommentFullStop` and `Squiz.Commenting.FunctionComment.EmptyThrows` from `WPGraphQL-Strict`.
 - dev: Update minimum PHPUnit version to `8.5.0`.

--- a/WPGraphQL-Minimum/ruleset.xml
+++ b/WPGraphQL-Minimum/ruleset.xml
@@ -37,7 +37,6 @@
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
 
 		<!-- Added back in WPGraphQL-Strict -->
-		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
 		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date"/>
 	</rule>
@@ -55,4 +54,6 @@
 
 	<!-- Enforce FQCN in comments -->
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
+	<!-- Enforce static closures -->
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
 </ruleset>

--- a/WPGraphQL-Strict/ruleset.xml
+++ b/WPGraphQL-Strict/ruleset.xml
@@ -30,9 +30,6 @@
 	<rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
 		<severity>5</severity>
 	</rule>
-	<rule ref="WordPress.WP.I18n.MissingTranslatorsComment">
-		<severity>5</severity>
-	</rule>
 
 	<!-- Additional commenting sniffs are in WPGraphQL-Docs -->
 	<rule ref="Squiz.Commenting.FunctionComment">
@@ -73,7 +70,6 @@
 	<rule ref="SlevomatCodingStandard.Exceptions.DisallowNonCapturingCatch" />
 	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
 
-	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
 	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
 	<rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "axepress/wp-graphql-cs",
 	"type": "phpcodesniffer-standard",
 	"description": "PHP_CodeSniffer rules (sniffs) for the WPGraphQL ecosystem.",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.3",
 	"keywords": [
 		"phpcs",
 		"wpcs",


### PR DESCRIPTION
- feat!: Move `WordPress.WP.I18n.MissingTranslatorsComment` from `WPGraphQL-Strict` to `WPGraphQL-Minimum`. (Added to WPGraphQL in https://github.com/wp-graphql/wp-graphql/pull/2856)
- feat!: Move `SlevomatCodingStandard.Functions.StaticClosure` from `WPGraphQL-Strict` to `WPGraphQL-Minimum`. (Added to WPGraphQL in https://github.com/wp-graphql/wp-graphql/pull/2855)
- chore: Update `slevomat/coding-standard` to `8.13.4`.
- chore: Update Composer dev-deps.