### PR TITLE
release: v1.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2023-08-17
+- feat!: Updated `WPGraphQL-Minimum` and `WPGraphQL-Strict` based on the latest changes to WPGraphQL core. (See https://github.com/wp-graphql/wp-graphql/compare/release/v1.14.10...develop#diff-05ae9cddcaec1e845771a7db224961439f83ef5939ec67d3a48744cb34d7e58b)
+- feat: Add `WPGraphQL-Core` coding standard, for a snapshot of what's currently being used upstream.
+
 ## [1.0.0-beta.3] - 2023-08-04
 - feat!: Move `WordPress.WP.I18n.MissingTranslatorsComment` from `WPGraphQL-Strict` to `WPGraphQL-Minimum`. (Added to WPGraphQL in https://github.com/wp-graphql/wp-graphql/pull/2856)
 - feat!: Move `SlevomatCodingStandard.Functions.StaticClosure` from `WPGraphQL-Strict` to `WPGraphQL-Minimum`. (Added to WPGraphQL in https://github.com/wp-graphql/wp-graphql/pull/2855)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The project provides a superset of sniffs that the WPGraphQL community may need.
 You can use the following standard names when invoking `phpcs` to select the sniffs you want to use.
 
 * [`WPGraphQL`](./WPGraphQL/ruleset.xml) - complete set with all of the sniffs in the project.
-  - [`WPGraphQL-Minimum`](./WPGraphQL-Minimum/ruleset.xml): basic ruleset for WPGraphQL projects, including all the sniffs used by the WPGraphQL plugin itself.
+  - [`WPGraphQL-Minimum`](./WPGraphQL-Minimum/ruleset.xml): basic ruleset for WPGraphQL projects.
   - [`WPGraphQL-Strict`](./WPGraphQL-Strict/ruleset.xml): includes all the sniffs in the `WPGraphQL-Minimum` ruleset, plus additional functional sniffs to help you produce enterprise-ready code.
+	- [`WPGraphQL-Core`](./WPGraphQL-Core/ruleset.xml): includes all the sniffs currently used by the WPGraphQL core project. Currently is the same as the `WPGraphQL-Strict` ruleset, with a few sniffs disabled.
   - [`WPGraphQL-Extra`](./WPGraphQL-Extra/ruleset.xml): includes all the sniffs in the `WPGraphQL-Strict` ruleset, plus additional formatting sniffs to keep your code looks consistent across your project.
   - [`WPGraphQL-Docs`](./WPGraphQL-Docs/ruleset.xml): includes sniffs for doc-blocks and inline comments.
 

--- a/WPGraphQL-Core/ruleset.xml
+++ b/WPGraphQL-Core/ruleset.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPGraphQL Core Coding Standard" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<description>Coding Standards used by the WPGraphQL core plugin.</description>
+
+	<!-- The rules below are the changes from between the original sniff or parent ruleset, and what should be applied for this Standard. -->
+
+	<!-- Load WordPress Coding standards -->
+	<rule ref="WPGraphQL-Strict" >
+			<!-- This would be a breaking change to fix in Core -->
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
+		<!-- Conflicts with b/c in AbstractConnectionResolver -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
+	</rule>
+
+</ruleset>

--- a/WPGraphQL-Minimum/ruleset.xml
+++ b/WPGraphQL-Minimum/ruleset.xml
@@ -8,37 +8,30 @@
 		<include-pattern>*\.php$</include-pattern>
 	</rule>
 
-	<!-- Load WordPress VIP Go standards - for use with projects on the (newer) VIP Go platform. -->
+	<!--
+		Load WordPress VIP Go standards
+		see: https://docs.wpvip.com/technical-references/vip-code-analysis-bot/phpcs-report/
+	-->
 	<rule ref="WordPress-VIP-Go" />
 
-	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
-
-	<rule ref="WordPress-Core">
+	<rule ref="WordPress">
+		<!-- Definitely should not be added back -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
+		<exclude name="WordPress.Files.FileName"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
 
 		<!-- Should probably not be added back -->
 		<exclude name="PHPCompatibility.Keywords.ForbiddenNamesAsDeclared.objectFound"/>
-
-		<!-- Added back in WPGraphQL-Strict -->
-		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
-	</rule>
-
-	<!-- Load WordPress Coding standards -->
-	<rule ref="WordPress">
-		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores"/>
-		<exclude name="WordPress.Files.FileName"/>
-
-		<!-- Definitely should not be added back -->
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
 
 		<!-- Added back in WPGraphQL-Strict -->
+		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
+		<!-- This would be a breaking change to fix in Core -->
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
-		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date"/>
 	</rule>
 
 	<!-- Tests for inline documentation of code -->
@@ -52,8 +45,30 @@
 	<!-- Enforce short array syntax -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
-	<!-- Enforce FQCN in comments -->
-	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
-	<!-- Enforce static closures -->
+	<!--
+		Slevomat sniffs
+		See: https://github.com/slevomat/coding-standard/tree/master#alphabetical-list-of-sniffs
+	-->
+	<rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch" />
+	<rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding" />
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator" />
+
 	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
+	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
+	<rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
+
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
+
+	<rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
+	<rule ref="SlevomatCodingStandard.PHP.TypeCast" />
+
+	<rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
+
 </ruleset>

--- a/WPGraphQL-Strict/ruleset.xml
+++ b/WPGraphQL-Strict/ruleset.xml
@@ -6,28 +6,23 @@
 
 	<!-- The rules below are the changes from between the original sniff or parent ruleset, and what should be applied for this Standard. -->
 
-	<!-- These are disabled in WPGraphQL core but should be reenabled. -->
+	<!-- These are disabled in WPGraphQL-Minimum but should be reenabled. -->
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
 		<properties>
 			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
-	<rule ref="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure">
+
+	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
 		<severity>5</severity>
 	</rule>
 	<rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-		<severity>5</severity>
-	</rule>
-	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
 		<severity>5</severity>
 	</rule>
 	<rule ref="PEAR.Functions.FunctionCallSignature.MultipleArguments">
 		<severity>5</severity>
 	</rule>
 	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
-		<severity>5</severity>
-	</rule>
-	<rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
 		<severity>5</severity>
 	</rule>
 
@@ -37,16 +32,19 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<properties>
-				<property name="skipIfInheritdoc" value="true" />
+			<property name="skipIfInheritdoc" value="true" />
 		</properties>
 	</rule>
 
-	<!-- Slevomat rules - subject to review -->
+	<!--
+		Slevomat sniffs
+		See: https://github.com/slevomat/coding-standard/tree/master#alphabetical-list-of-sniffs
+	-->
 	<rule ref="SlevomatCodingStandard.Arrays">
-		<!-- Conflicts with WPCS -->
-		<exclude name="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
 		<!-- Semantic sorting is a valid pattern -->
 		<exclude name="SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys"/>
+		<!-- Conflicts with WPCS -->
+		<exclude name="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
 	</rule>
 
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference">
@@ -56,30 +54,13 @@
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Classes.RequireSelfReference" />
-	<rule ref="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion" />
-	<rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
-	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition" />
-	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition" />
-	<rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch" />
-	<rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
-	<rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding" />
-
-	<rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator" />
 
 	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
 	<rule ref="SlevomatCodingStandard.Exceptions.DisallowNonCapturingCatch" />
 	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
 
-	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
-	<rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
-
 	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses" />
-	<rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
 
-	<rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
-	<rule ref="SlevomatCodingStandard.PHP.TypeCast" />
-
-	<rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
 	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable" >
 		<properties>
 			<property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />


### PR DESCRIPTION
Update rulesets and add `WPGraphQL-Core` ruleset for a current plugin snapshot.