### PR TITLE
release: 2.0.0-beta 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [2.0.0-beta.3] - @todo
+
+This release explicitly adds `Squiz.WhiteSpace.SuperfluousWhitespace` to the `WPGraphQL-Extra` ruleset, as it is silenced by VIPCS.
+
+### WPGraphQL-Extra
+- Added `Squiz.WhiteSpace.SuperfluousWhitespace` and made explicit.
+
 ## [2.0.0-beta.2] - 2023-11-5
 
 This release updates the ruleset based on the latest changes to WPGraphQL core (v1.18.0). Specifically:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
-## [2.0.0-beta.3] - @todo
+## [2.0.0-beta.3] - 2024-04-05
 
 This release explicitly adds `Squiz.WhiteSpace.SuperfluousWhitespace` to the `WPGraphQL-Extra` ruleset, as it is silenced by VIPCS.
 

--- a/WPGraphQL-Extra/ruleset.xml
+++ b/WPGraphQL-Extra/ruleset.xml
@@ -6,7 +6,18 @@
 
 	<!-- The rules below are the changes from between the original sniff or parent ruleset, and what should be applied for this Standard. -->
 
-	<!-- The following rules enforce code formatting standards.-->
+	<!-- These formatting rules are suppressed in VIP-GO and restored here.-->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine">
+		<severity>5</severity>
+	</rule>
+
+	<!-- The following Slevomat rules enforce code formatting standards.-->
 	<rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing" />
 	<rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing" />
 	<rule ref="SlevomatCodingStandard.Classes.ConstantSpacing" />

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "axepress/wp-graphql-cs",
 	"type": "phpcodesniffer-standard",
 	"description": "PHP_CodeSniffer rules (sniffs) for the WPGraphQL ecosystem.",
-	"version": "2.0.0-beta.2",
+	"version": "2.0.0-beta.3",
 	"keywords": [
 		"phpcs",
 		"wpcs",


### PR DESCRIPTION
This PR restores ` Squiz.WhiteSpace.SuperfluousWhitespace` (silenced by VIPCS), and bumps the version.